### PR TITLE
🛠️ build: add .gitignore file for iOS project to exclude unnecessary …

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,33 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+.xcode.env.local
+
+# Bundle artifacts
+*.jsbundle
+
+# CocoaPods
+/Pods/
+
+# Ignore the entire ios folder
+ios/


### PR DESCRIPTION
This pull request adds a `.gitignore` file to the `ios` directory to exclude unnecessary files and folders from version control. The changes ensure that files generated by macOS, Xcode, CocoaPods, and build processes are ignored.

### Added `.gitignore` entries for:

* **macOS-related files**: Excludes `.DS_Store` files.
* **Xcode-specific files**: Ignores build artifacts, user-specific settings (`*.pbxuser`, `*.mode1v3`, etc.), derived data, and workspace files (`project.xcworkspace`).
* **Bundle artifacts**: Prevents inclusion of `*.jsbundle` files.
* **CocoaPods dependencies**: Excludes the `/Pods/` directory.
* **Entire `ios` folder**: Ensures the entire `ios` directory is ignored.